### PR TITLE
FIX: Testing CDN import to fix install issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,9 @@
 
     <!-- using `script` -->
     <script src="https://unpkg.com/image-map/dist/image-map.js"></script>
-    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"
+            crossorigin="anonymous"></script>
     
     <script type="text/javascript">
         getVideos(5);

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@
 // This includes Popper and all of Bootstrap's JS plugins.
 
 import "../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js";
-
+import bootstrap from 'https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/+esm';
 
 //
 // Place any custom JS here


### PR DESCRIPTION
PRIORITY FIX: Bootstrap wasn't installed in production meaning the alert wouldn't close.

HOTFIX:
- Adding the CDN to the index.html.

PREFERABLE FUTURE:
- Build the Bootstrap JS in production rather than being set to a very specific version!